### PR TITLE
fix builds on debian

### DIFF
--- a/goapache_build_linux.go
+++ b/goapache_build_linux.go
@@ -9,6 +9,7 @@ package goapache
 //    HTTPD
 //
 #cgo CFLAGS: -I/usr/include/httpd
+#cgo CFLAGS: -I/usr/include/apache2
 
 //
 //    (A)pache (P)ortable (R)untime


### PR DESCRIPTION
Debian/Ubuntu use different include paths. This patch enables builds on those platforms.